### PR TITLE
Job queue for FAIR Assessments on submissions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,10 @@
-__pycache__
-.DS_Store
-.env
-# Keep environment variables out of version control
+.git
+**/__pycache__/
+**/.DS_Store
+**/.env
 current/
 kub/
-node_modules
+**/node_modules/
 output/
 outreach_files/
 package-lock.json
@@ -14,3 +14,8 @@ publication_files/
 tool_files/
 usecase_files/
 venv
+**/.venv/
+**/.next/
+drc-portals/public/**
+database/C2M2/ingest/**
+database/ingest/**

--- a/database/.dockerignore
+++ b/database/.dockerignore
@@ -1,8 +1,8 @@
-__pycache__
+**/__pycache__/
 .cached
-C2M2/ingest
-C2M2/log
+C2M2/ingest/**
+C2M2/log/**
 data
 fair
 fairshake.ipynb
-ingest
+ingest/**

--- a/database/fair_assessment/assess_fair.py
+++ b/database/fair_assessment/assess_fair.py
@@ -26,91 +26,86 @@ def assess_dcc_asset(row):
     """Runs fair assessment for a single DCC asset
     row: Row containing asset information with same fields as that in a dataframe returned by either current_dcc_assets() or current_code_assets()
     """
-    with fair_assessments_helper.writer() as fair_assessment:
-        asset_type = ''
-        rubric = {}
-        if 'type' in row: 
-            asset_type = row['type']
-            if asset_type == 'ETL': 
-                rubric= etl_fair(row['link'])
-            if asset_type == 'Entity Page Template': 
-                rubric = entity_page_fair(row['entityPageExample'], row['link'])
-            if asset_type == 'PWB Metanodes':
-                rubric = PWB_metanode_fair(row['name'], row['link'])
-            if asset_type == 'API':
-                rubric = api_fair(row)
-            if asset_type == 'Apps URL':
-                rubric = apps_urls_fair(row['link'])
-            if asset_type == 'Chatbot Specifications':
-                rubric = chatbot_specs_fair(row['link'])
-        else: 
-            asset_type = row['filetype']
-            row['dcc_short_label'] = row['link'].split('/')[3]
-            if asset_type == 'XMT': 
-                xmts_path = ingest_path / 'xmts'
-                xmt_path = xmts_path/row['dcc_short_label']/row['filename']
-                xmt_path.parent.mkdir(parents=True, exist_ok=True)
-                if not xmt_path.exists():
-                    import urllib.request
-                    urllib.request.urlretrieve(row['link'].replace(' ', '%20'), xmt_path)
-                rubric = xmt_fair(xmt_path, row)
-            if asset_type == 'Attribute Table': 
-                attr_tables_path = ingest_path / 'attribute_tables'
-                attr_table_path = attr_tables_path/row['dcc_short_label']/row['filename']
-                attr_table_path.parent.mkdir(parents=True, exist_ok=True)
-                if not attr_table_path.exists():
-                    import urllib.request
-                    urllib.request.urlretrieve(row['link'].replace(' ', '%20'), attr_table_path)
-                rubric = attribute_tables_fair(attr_table_path, row)
-            if asset_type == 'C2M2': 
-                c2m2s_path = ingest_path / 'c2m2s'
-                c2m2_path = c2m2s_path/row['dcc_short_label']/row['filename']
-                c2m2_path.parent.mkdir(parents=True, exist_ok=True)
-                if not c2m2_path.exists():
-                    import urllib.request
-                    urllib.request.urlretrieve(row['link'].replace(' ', '%20'), c2m2_path)
-                c2m2_extract_path = c2m2_path.parent / c2m2_path.stem
-                if not c2m2_extract_path.exists():
-                    with zipfile.ZipFile(c2m2_path, 'r') as c2m2_zip:
-                        c2m2_zip.extractall(c2m2_extract_path)
-                # run fair assessment here: 
-                rubric = c2m2_fair(str(c2m2_extract_path))
-            if asset_type == 'KG Assertions': 
-                assertions_path = ingest_path / 'assertions'
-                # assemble the full file path for the DCC's asset
-                file_path = assertions_path/row['dcc_short_label']/row['filename']
-                file_path.parent.mkdir(parents=True, exist_ok=True)
-                if not file_path.exists():
-                    import urllib.request
-                    urllib.request.urlretrieve(row['link'].replace(' ', '%20'), file_path)
-                # extract the KG Assertion bundle
-                assertions_extract_path = file_path.parent / file_path.stem
-                if not assertions_extract_path.exists():
-                    with zipfile.ZipFile(file_path, 'r') as assertions_zip:
-                        assertions_zip.extractall(assertions_extract_path)
-                rubric = kg_assertions_fair(assertions_extract_path)                
-        fair_timestamp = datetime.now()
-        fair_assessment.writerow(dict( #add fair assessment to database
-            id=str(uuid5(uuid0, '\t'.join((row['link'], str(fair_timestamp))))), 
-            dcc_id=row['dcc_id'],
-            type=asset_type,
-            link=row['link'],
-            rubric=json.dumps(rubric),
-            timestamp=fair_timestamp
-            ))
-    return rubric
+    asset_type = ''
+    rubric = {}
+    if 'type' in row: 
+        asset_type = row['type']
+        if asset_type == 'ETL': 
+            rubric= etl_fair(row['link'])
+        if asset_type == 'Entity Page Template': 
+            rubric = entity_page_fair(row['entityPageExample'], row['link'])
+        if asset_type == 'PWB Metanodes':
+            rubric = PWB_metanode_fair(row['name'], row['link'])
+        if asset_type == 'API':
+            rubric = api_fair(row)
+        if asset_type == 'Apps URL':
+            rubric = apps_urls_fair(row['link'])
+        if asset_type == 'Chatbot Specifications':
+            rubric = chatbot_specs_fair(row['link'])
+    else: 
+        asset_type = row['filetype']
+        row['dcc_short_label'] = row['link'].split('/')[3]
+        if asset_type == 'XMT': 
+            xmts_path = ingest_path / 'xmts'
+            xmt_path = xmts_path/row['dcc_short_label']/row['filename']
+            xmt_path.parent.mkdir(parents=True, exist_ok=True)
+            if not xmt_path.exists():
+                import urllib.request
+                urllib.request.urlretrieve(row['link'].replace(' ', '%20'), xmt_path)
+            rubric = xmt_fair(xmt_path, row)
+        if asset_type == 'Attribute Table': 
+            attr_tables_path = ingest_path / 'attribute_tables'
+            attr_table_path = attr_tables_path/row['dcc_short_label']/row['filename']
+            attr_table_path.parent.mkdir(parents=True, exist_ok=True)
+            if not attr_table_path.exists():
+                import urllib.request
+                urllib.request.urlretrieve(row['link'].replace(' ', '%20'), attr_table_path)
+            rubric = attribute_tables_fair(attr_table_path, row)
+        if asset_type == 'C2M2': 
+            c2m2s_path = ingest_path / 'c2m2s'
+            c2m2_path = c2m2s_path/row['dcc_short_label']/row['filename']
+            c2m2_path.parent.mkdir(parents=True, exist_ok=True)
+            if not c2m2_path.exists():
+                import urllib.request
+                urllib.request.urlretrieve(row['link'].replace(' ', '%20'), c2m2_path)
+            c2m2_extract_path = c2m2_path.parent / c2m2_path.stem
+            if not c2m2_extract_path.exists():
+                with zipfile.ZipFile(c2m2_path, 'r') as c2m2_zip:
+                    c2m2_zip.extractall(c2m2_extract_path)
+            # run fair assessment here: 
+            rubric = c2m2_fair(str(c2m2_extract_path))
+        if asset_type == 'KG Assertions': 
+            assertions_path = ingest_path / 'assertions'
+            # assemble the full file path for the DCC's asset
+            file_path = assertions_path/row['dcc_short_label']/row['filename']
+            file_path.parent.mkdir(parents=True, exist_ok=True)
+            if not file_path.exists():
+                import urllib.request
+                urllib.request.urlretrieve(row['link'].replace(' ', '%20'), file_path)
+            # extract the KG Assertion bundle
+            assertions_extract_path = file_path.parent / file_path.stem
+            if not assertions_extract_path.exists():
+                with zipfile.ZipFile(file_path, 'r') as assertions_zip:
+                    assertions_zip.extractall(assertions_extract_path)
+            rubric = kg_assertions_fair(assertions_extract_path)                
+    fair_timestamp = datetime.now()
+    return dict(
+        id=str(uuid5(uuid0, '\t'.join((row['link'], str(fair_timestamp))))), 
+        dcc_id=row['dcc_id'],
+        type=asset_type,
+        link=row['link'],
+        rubric=json.dumps(rubric),
+        timestamp=fair_timestamp.isoformat(),
+    )
 
-
-# perform fair assessment of code assets
-code_fair_assessment_df = code_assets_fair_assessment()
-# perform fair assessment on file assets 
-file_fair_assessment_df = file_assets_fair_assessment()
-frames = [code_fair_assessment_df, file_fair_assessment_df]
-fair_assessment_df = pd.concat(frames, ignore_index=True)
-copy_from_records(connection, 'fair_assessments', ['id', 'dcc_id', 'type', 'link', 'rubric', 'timestamp'], (
-  dict(id=str(uuid5(uuid0, '\t'.join((row['link'], str(row['timestamp']))))), dcc_id=row['dcc_id'], type=row['type'], link=row['link'], rubric=json.dumps(row['rubric']), timestamp=row['timestamp'])
-    for index, row in tqdm(fair_assessment_df.iterrows(), total=fair_assessment_df.shape[0], desc='Ingesting fair assessment results...')
-), on=OnConflictSpec(conflict=("link", "timestamp"), update=('rubric')))
-
-
-        
+if __name__ == '__main__':
+    # perform fair assessment of code assets
+    code_fair_assessment_df = code_assets_fair_assessment()
+    # perform fair assessment on file assets 
+    file_fair_assessment_df = file_assets_fair_assessment()
+    frames = [code_fair_assessment_df, file_fair_assessment_df]
+    fair_assessment_df = pd.concat(frames, ignore_index=True)
+    copy_from_records(connection, 'fair_assessments', ['id', 'dcc_id', 'type', 'link', 'rubric', 'timestamp'], (
+    dict(id=str(uuid5(uuid0, '\t'.join((row['link'], str(row['timestamp']))))), dcc_id=row['dcc_id'], type=row['type'], link=row['link'], rubric=json.dumps(row['rubric']), timestamp=row['timestamp'])
+        for index, row in tqdm(fair_assessment_df.iterrows(), total=fair_assessment_df.shape[0], desc='Ingesting fair assessment results...')
+    ), on=OnConflictSpec(conflict=("link", "timestamp"), update=('rubric')))

--- a/database/fair_assessment/assess_fair.py
+++ b/database/fair_assessment/assess_fair.py
@@ -94,7 +94,7 @@ def assess_dcc_asset(row):
         dcc_id=row['dcc_id'],
         type=asset_type,
         link=row['link'],
-        rubric=json.dumps(rubric),
+        rubric=rubric,
         timestamp=fair_timestamp.isoformat(),
     )
 

--- a/database/fair_assessment/fairshake.py
+++ b/database/fair_assessment/fairshake.py
@@ -45,11 +45,12 @@ def find_between_r( s, first, last ):
     
 def check_repo_public(github_url):
     """Checks if the GitHub URL is the link of a public repo."""
-    x = requests.head(github_url)
-    if x.status_code == 200: 
-        return True
-    else:
-        return False
+    try:
+        x = requests.head(github_url)
+        return x.status_code == 200
+    except KeyboardInterrupt: raise
+    except: pass
+    return False
   
 def get_repo_license(github_url):
     """Extracts the license information from a GitHub repository URL using the API."""
@@ -57,13 +58,13 @@ def get_repo_license(github_url):
     repo_url = github_url.split("/")
     owner, repo = repo_url[3], repo_url[4]
     api_url = f"https://api.github.com/repos/{owner}/{repo}/license"
-    response = requests.get(api_url)
-    if response.status_code == 200:
+    try:
+        response = requests.get(api_url)
+        response.raise_for_status()
         data = response.json()
         return data['license']['name']
-    else:
-        return None
-    
+    except KeyboardInterrupt: raise
+    except: pass
 
 def assess_metanode(metanode_name):
     """Run FAIR Assessment for a given PWB metanode given its name using the PWB components API endpoint."""
@@ -73,8 +74,9 @@ def assess_metanode(metanode_name):
     fairshake_license = 0
     fairshake_persistent_url = 0
     metanode_name = metanode_name
-    response= requests.get('https://playbook-workflow-builder.cloud/api/components/' + metanode_name)
-    if response.ok: 
+    try:
+        response= requests.get('https://playbook-workflow-builder.cloud/api/components/' + metanode_name)
+        response.raise_for_status()
         metanode_info = response.json()
         metadata = metanode_info['meta']
         if metadata['description'] != "":
@@ -91,8 +93,8 @@ def assess_metanode(metanode_name):
         else:
             fairshake_cite_methods = None
         return  [fairshake_description, fairshake_cite_methods, fairshake_contact_info, fairshake_license, fairshake_persistent_url]
-    else:
-        return None
+    except KeyboardInterrupt: raise
+    except: pass
 
 
 def format_PWB_results(result):
@@ -112,7 +114,12 @@ def PWB_metanode_fair(row_name, row_url):
         split_url = urlsplit(row_url.replace('/nih-cfde/playbook-partnership/blob/', '/MaayanLab/Playbook-Workflow-Builder/'))
         base_url = split_url.netloc
         if base_url ==  'github.com': #if url was a github url
-            metanode_names = re.findall("= MetaNode\('.+?\)", requests.get('https://raw.githubusercontent.com' + split_url.path).text)
+            try:
+                text = requests.get('https://raw.githubusercontent.com' + split_url.path).text
+            except KeyboardInterrupt: raise
+            except:
+                text = ''
+            metanode_names = re.findall("= MetaNode\('.+?\)", text)
             metanode_name = split_url.path.split('/')[-2]
             result = assess_metanode(metanode_name)
             if result != None:
@@ -147,13 +154,19 @@ def entity_page_fair(entityPageExample, link):
     template_url = link
     try:
         if type(example_url) == 'string':
+            try:
                 x = requests.head(example_url)
-                if x.ok:
-                    fairshake_head_request_support = 1
+                x.raise_for_status()
+                fairshake_head_request_support = 1
+            except KeyboardInterrupt: raise
+            except: pass
         example_term = find_between_r(template_url, '%7B', '%7D' ) 
         missing_element_url = template_url.replace('%7B' +example_term+ '%7D', 'thisstringshouldhopefullynotmatchanything')
-        if requests.head(missing_element_url).status_code == 404:
-            fairshake_return_404 = 1
+        try:
+            if requests.head(missing_element_url).status_code == 404:
+                fairshake_return_404 = 1
+        except KeyboardInterrupt: raise
+        except: pass
         check_url_templated = re.search("^.*%7B.*%7D.*$", template_url)
         if not(check_url_templated):
             check_url_templated = re.search("^.*{.*}.*$", template_url)
@@ -235,8 +248,9 @@ def apps_urls_fair(apps_url):
     fairshake_license = 0
     fairshake_description = 0
     fairshake_persistent_url = 0 
-    response = requests.get(apps_url)
-    if response.ok:
+    try:
+        response = requests.get(apps_url)
+        response.raise_for_status()
         html = response.text
         soup = BeautifulSoup(html, features="html.parser")
         schema_json = soup.find('script', type='application/ld+json')
@@ -250,6 +264,8 @@ def apps_urls_fair(apps_url):
                         fairshake_license = 1
                     if 'description' in webpageObject: 
                         fairshake_description = 1
+    except KeyboardInterrupt: raise
+    except: pass
     rubric = {"Resource discovery through web search": fairshake_description,
             "Digital resource license": fairshake_license,
             "Persistent URL": fairshake_persistent_url}
@@ -263,8 +279,9 @@ def chatbot_specs_fair(chatbot_specs_url):
     fairshake_valid_openapi_link = 0
     fairshake_contact = 0
     fairshake_ogp = [0] * 4
-    response = requests.get(chatbot_specs_url)
-    if response.ok:
+    try:
+        response = requests.get(chatbot_specs_url)
+        response.raise_for_status()
         chatbot_specs = response.json()
         # check if ai-plugin compatible
         required_plugin_fields = ['schema_version', 'name_for_human', 'name_for_model', 'description_for_model', 'description_for_human', 'api']
@@ -272,12 +289,19 @@ def chatbot_specs_fair(chatbot_specs_url):
             if field in chatbot_specs: 
                 fairshake_aiplugin_compatible[index] = 1
         if 'api' in chatbot_specs and chatbot_specs['api']['type'] == 'openapi':
-            openapi_json_response = requests.get(chatbot_specs['api']['url'])
-            fairshake_valid_openapi_link = 1 if openapi_json_response.ok else 0
+            try:
+                openapi_json_response = requests.get(chatbot_specs['api']['url'])
+                openapi_json_response.raise_for_status()
+            except KeyboardInterrupt: raise
+            except: fairshake_valid_openapi_link = 0
+            else: fairshake_valid_openapi_link = 1
         fairshake_contact = 1 if 'contact_email' in chatbot_specs else 0
+    except KeyboardInterrupt: raise
+    except: pass
     split_url = urlsplit(chatbot_specs_url)
-    webpage_response = requests.get(split_url.scheme + '://' + split_url.netloc)
-    if webpage_response.ok:
+    try:
+        webpage_response = requests.get(split_url.scheme + '://' + split_url.netloc)
+        webpage_response.raise_for_status()
         html = webpage_response.text
         soup = BeautifulSoup(html, features="html.parser")
         ogp_title = soup.find('meta', property="og:title")
@@ -288,6 +312,8 @@ def chatbot_specs_fair(chatbot_specs_url):
         for index, ogp_req in enumerate(ogp_req_metadata): 
             if ogp_req:
                 fairshake_ogp[index] = 1
+    except KeyboardInterrupt: raise
+    except: pass
     rubric = {"Compatible with AI Plugins": mean(fairshake_aiplugin_compatible),
               "Chatbot Specs contain valid OpenAPI Specifications documentation": fairshake_valid_openapi_link, 
               "Website has Open Graph protocol for ChatBot usage": mean(fairshake_ogp),

--- a/database/fair_assessment/fairshake.py
+++ b/database/fair_assessment/fairshake.py
@@ -26,6 +26,7 @@ from c2m2_assessment.util.memo import memo
 from ontology.obo import OBOOntology
 from ingest_common import current_code_assets, current_dcc_assets
 import zipfile
+import traceback
 import logging; logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
 
 
@@ -49,7 +50,7 @@ def check_repo_public(github_url):
         x = requests.head(github_url)
         return x.status_code == 200
     except KeyboardInterrupt: raise
-    except: pass
+    except: traceback.print_exc(file=sys.stderr)
     return False
   
 def get_repo_license(github_url):
@@ -64,7 +65,7 @@ def get_repo_license(github_url):
         data = response.json()
         return data['license']['name']
     except KeyboardInterrupt: raise
-    except: pass
+    except: traceback.print_exc(file=sys.stderr)
 
 def assess_metanode(metanode_name):
     """Run FAIR Assessment for a given PWB metanode given its name using the PWB components API endpoint."""
@@ -94,7 +95,7 @@ def assess_metanode(metanode_name):
             fairshake_cite_methods = None
         return  [fairshake_description, fairshake_cite_methods, fairshake_contact_info, fairshake_license, fairshake_persistent_url]
     except KeyboardInterrupt: raise
-    except: pass
+    except: traceback.print_exc(file=sys.stderr)
 
 
 def format_PWB_results(result):
@@ -159,14 +160,14 @@ def entity_page_fair(entityPageExample, link):
                 x.raise_for_status()
                 fairshake_head_request_support = 1
             except KeyboardInterrupt: raise
-            except: pass
+            except: traceback.print_exc(file=sys.stderr)
         example_term = find_between_r(template_url, '%7B', '%7D' ) 
         missing_element_url = template_url.replace('%7B' +example_term+ '%7D', 'thisstringshouldhopefullynotmatchanything')
         try:
             if requests.head(missing_element_url).status_code == 404:
                 fairshake_return_404 = 1
         except KeyboardInterrupt: raise
-        except: pass
+        except: traceback.print_exc(file=sys.stderr)
         check_url_templated = re.search("^.*%7B.*%7D.*$", template_url)
         if not(check_url_templated):
             check_url_templated = re.search("^.*{.*}.*$", template_url)
@@ -265,7 +266,7 @@ def apps_urls_fair(apps_url):
                     if 'description' in webpageObject: 
                         fairshake_description = 1
     except KeyboardInterrupt: raise
-    except: pass
+    except: traceback.print_exc(file=sys.stderr)
     rubric = {"Resource discovery through web search": fairshake_description,
             "Digital resource license": fairshake_license,
             "Persistent URL": fairshake_persistent_url}
@@ -297,7 +298,7 @@ def chatbot_specs_fair(chatbot_specs_url):
             else: fairshake_valid_openapi_link = 1
         fairshake_contact = 1 if 'contact_email' in chatbot_specs else 0
     except KeyboardInterrupt: raise
-    except: pass
+    except: traceback.print_exc(file=sys.stderr)
     split_url = urlsplit(chatbot_specs_url)
     try:
         webpage_response = requests.get(split_url.scheme + '://' + split_url.netloc)
@@ -313,7 +314,7 @@ def chatbot_specs_fair(chatbot_specs_url):
             if ogp_req:
                 fairshake_ogp[index] = 1
     except KeyboardInterrupt: raise
-    except: pass
+    except: traceback.print_exc(file=sys.stderr)
     rubric = {"Compatible with AI Plugins": mean(fairshake_aiplugin_compatible),
               "Chatbot Specs contain valid OpenAPI Specifications documentation": fairshake_valid_openapi_link, 
               "Website has Open Graph protocol for ChatBot usage": mean(fairshake_ogp),

--- a/drc-portals/app/data/submit/urlform/UploadCode.tsx
+++ b/drc-portals/app/data/submit/urlform/UploadCode.tsx
@@ -149,6 +149,7 @@ export const updateCodeAsset = async (name: string, assetType: string, url: stri
             }
         }
     });
+    await queue_fairshake({ link: url })
 }
 
 

--- a/drc-portals/app/data/submit/urlform/UploadCode.tsx
+++ b/drc-portals/app/data/submit/urlform/UploadCode.tsx
@@ -8,6 +8,7 @@ import { render } from '@react-email/render';
 import { AssetSubmitReceiptEmail, DCCApproverUploadEmail } from '../Email';
 
 import nodemailer from 'nodemailer'
+import { queue_fairshake } from '@/tasks/fairshake';
 
 
 
@@ -79,7 +80,7 @@ export const saveCodeAsset = async (name: string, assetType: string, url: string
             codeAsset: true
         }
     })
-
+    await queue_fairshake({ link: url })
     const receipt = await sendUploadReceipt(session.user, savedCode);
     const dccApproverAlert = await sendDCCApproverEmail(session.user, formDcc, savedCode);
     // const drcApproverAlert = await sendDRCApproverEmail(user, formDcc, savedCode);

--- a/drc-portals/docker-compose.yaml
+++ b/drc-portals/docker-compose.yaml
@@ -64,6 +64,18 @@ services:
       - NEXT_PUBLIC_GA_MEASUREMENT_ID
       - ASSISTANT_ID
 
+  drc-portal-worker:
+    build:
+      context: ..
+      dockerfile: worker/Dockerfile
+    platform: linux/amd64
+    image: maayanlab/drc-portal-worker:0.10.29
+    x-kubernetes:
+      imagePullPolicy: IfNotPresent
+    environment:
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${PRIMARY_DATABASE}:5432/${POSTGRES_DB}?schema=public&pool_timeout=0&connection_limit=10&connect_timeout=30
+      - C2M2_DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${PRIMARY_DATABASE}:5432/${POSTGRES_DB}?schema=c2m2&pool_timeout=0&connection_limit=10&connect_timeout=30
+
   drc-portal-data-proxy:
     image: maayanlab/proxy:1.2.9
     x-kubernetes:

--- a/drc-portals/graphile.config.ts
+++ b/drc-portals/graphile.config.ts
@@ -1,0 +1,12 @@
+import type {} from "graphile-config";
+import type {} from "graphile-worker";
+
+const preset: GraphileConfig.Preset = {
+  worker: {
+    connectionString: process.env.DATABASE_URL,
+    concurrentJobs: 5,
+    fileExtensions: [".js", ".cjs", ".mjs", ".ts"],
+  },
+};
+
+export default preset;

--- a/drc-portals/lib/graphile/index.ts
+++ b/drc-portals/lib/graphile/index.ts
@@ -1,0 +1,13 @@
+import singleton from '@/lib/singleton'
+import { makeWorkerUtils } from 'graphile-worker'
+
+export default singleton('graphile-worker-utils', async () => {
+  const workerUtils = await makeWorkerUtils({
+    connectionString: process.env.DATABASE_URL,
+  })
+  await workerUtils.migrate()
+  process.on('exit', () => {
+    workerUtils.release()
+  })
+  return workerUtils
+})

--- a/drc-portals/package-lock.json
+++ b/drc-portals/package-lock.json
@@ -40,6 +40,7 @@
         "crypto-js": "^4.2.0",
         "fairshakeinsignia": "^1.0.3",
         "fs": "^0.0.1-security",
+        "graphile-worker": "^0.16.6",
         "html-entities": "^2.5.2",
         "js-cookie": "^3.0.5",
         "js-file-download": "^0.4.12",
@@ -79,11 +80,13 @@
         "@types/react-dom": "^18",
         "@types/react-plotly.js": "^2.6.3",
         "autoprefixer": "^10.0.1",
+        "dotenv": "^16.4.5",
         "postcss": "^8",
         "prisma": "^5.7.0",
         "sharp": "^0.32.6",
         "tailwindcss": "^3.3.0",
-        "ts-node": "^10.9.1",
+        "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
         "typescript": "^5"
       }
     },
@@ -3972,7 +3975,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -3984,7 +3987,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -4138,6 +4141,201 @@
         "node": ">=12"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "peer": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
+      "peer": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+      "peer": true,
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.4",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
+      "integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.0.tgz",
+      "integrity": "sha512-LPkkenkDqyzTFauZLLAPhIb48fj6drrfMvRGSL9tS3AcZBSVTllemLSNyCvHNNL2t797S/6DJNSIwRwXgMO/eQ==",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
+      "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
+      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "peer": true,
+      "dependencies": {
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit/node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
@@ -4171,6 +4369,37 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
+    },
+    "node_modules/@graphile/logger": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@graphile/logger/-/logger-0.2.0.tgz",
+      "integrity": "sha512-jjcWBokl9eb1gVJ85QmoaQ73CQ52xAaOCF29ukRbYNl6lY+ts0ErTaDYOBlejcbUs2OpaiqYLO5uDhyLFzWw4w=="
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "peer": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.0.tgz",
+      "integrity": "sha512-d2CGZR2o7fS6sWB7DG/3a95bGKQyHMACZ5aW8qGkkqQpUoZV6C0X7Pc7l4ZNMZkfNBf4VWNe9E1jRsf0G146Ew==",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -4931,13 +5160,13 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.7.0.tgz",
       "integrity": "sha512-tZ+MOjWlVvz1kOEhNYMa4QUGURY+kgOUBqLHYIV8jmCsMuvA1tWcn7qtIMLzYWCbDcQT4ZS8xDgK0R2gl6/0wA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@prisma/engines": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.7.0.tgz",
       "integrity": "sha512-TkOMgMm60n5YgEKPn9erIvFX2/QuWnl3GBo6yTRyZKk5O5KQertXiNnrYgSLy0SpsKmhovEPQb+D4l0SzyE7XA==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/debug": "5.7.0",
@@ -4950,13 +5179,13 @@
       "version": "5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9.tgz",
       "integrity": "sha512-V6tgRVi62jRwTm0Hglky3Scwjr/AKFBFtS+MdbsBr7UOuiu1TKLPc6xfPiyEN1+bYqjEtjxwGsHgahcJsd1rNg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.7.0.tgz",
       "integrity": "sha512-zIn/qmO+N/3FYe7/L9o+yZseIU8ivh4NdPKSkQRIHfg2QVTVMnbhGoTcecbxfVubeTp+DjcbjS0H9fCuM4W04w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@prisma/debug": "5.7.0",
         "@prisma/engines-version": "5.7.0-41.79fb5193cf0a8fdbef536e4b4a159cad677ab1b9",
@@ -4967,7 +5196,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.7.0.tgz",
       "integrity": "sha512-ZeV/Op4bZsWXuw5Tg05WwRI8BlKiRFhsixPcAM+5BKYSiUZiMKIi713tfT3drBq8+T0E1arNZgYSA9QYcglWNA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@prisma/debug": "5.7.0"
       }
@@ -6901,25 +7130,25 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
       "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@turf/area": {
       "version": "6.5.0",
@@ -7051,6 +7280,14 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/interpret": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/interpret/-/interpret-1.1.3.tgz",
+      "integrity": "sha512-uBaBhj/BhilG58r64mtDb/BEdH51HIQLgP5bmWzc5qCtFMja8dCk/IOJmk36j0lbi9QHwI6sbtUNGuqXdKCAtQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/js-cookie": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-3.0.6.tgz",
@@ -7119,6 +7356,16 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
     },
+    "node_modules/@types/pg": {
+      "version": "8.11.10",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.10.tgz",
+      "integrity": "sha512-LczQUW4dbOQzsH2RQ5qoeJ6qJPdrcM/DcMLoqWQkMLMsq83J5lAX3LXjdkWdpscFy67JSOWDnh7Ny/sPFykmkg==",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
     "node_modules/@types/plotly.js": {
       "version": "2.12.30",
       "resolved": "https://registry.npmjs.org/@types/plotly.js/-/plotly.js-2.12.30.tgz",
@@ -7175,6 +7422,11 @@
       "version": "0.16.5",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.5.tgz",
       "integrity": "sha512-s/FPdYRmZR8SjLWGMCuax7r3qCWQw9QKHzXVukAuuIJkXkDRwp+Pu5LMIVFi0Fxbav35WURicYr8u1QsoybnQw=="
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ=="
     },
     "node_modules/@types/unist": {
       "version": "3.0.2",
@@ -7374,9 +7626,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-      "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+      "version": "8.12.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
+      "integrity": "sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7404,7 +7656,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
       "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8159,6 +8411,83 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
@@ -8461,7 +8790,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -9225,7 +9554,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -9314,11 +9643,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/draw-svg-path": {
@@ -9747,6 +10080,65 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.0.tgz",
+      "integrity": "sha512-yVS6XODx+tMFMDFcG4+Hlh+qG7RM6cCJXtQhCKLSsr3XkLvWggHjCqjfh0XsPPnt1c56oaT6PMgW9XWQQjdHXA==",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.11.0",
+        "@eslint/config-array": "^0.18.0",
+        "@eslint/eslintrc": "^3.1.0",
+        "@eslint/js": "9.11.0",
+        "@eslint/plugin-kit": "^0.2.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.3.0",
+        "@nodelib/fs.walk": "^1.2.8",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.0.2",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.1.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-config-prettier": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
@@ -9780,6 +10172,189 @@
         "eslint": ">6.6.0"
       }
     },
+    "node_modules/eslint-plugin-turbo/node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.2.tgz",
+      "integrity": "sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==",
+      "peer": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "peer": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "peer": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/eslint/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "peer": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "peer": true
+    },
+    "node_modules/eslint/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "peer": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/eslint/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/eslint/node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/esniff": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
@@ -9799,6 +10374,23 @@
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
       "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw=="
     },
+    "node_modules/espree": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
+      "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.12.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -9809,6 +10401,27 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/esrecurse": {
@@ -10119,6 +10732,18 @@
         "node-fetch": "~2.6.1"
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "peer": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -10134,6 +10759,41 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "peer": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
+      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+      "peer": true
     },
     "node_modules/flatten-vertex-data": {
       "version": "1.0.2",
@@ -10381,6 +11041,14 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
       "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg=="
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
     },
     "node_modules/get-canvas-context": {
       "version": "1.0.2",
@@ -10734,6 +11402,160 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
+    "node_modules/graphile-config": {
+      "version": "0.0.1-beta.9",
+      "resolved": "https://registry.npmjs.org/graphile-config/-/graphile-config-0.0.1-beta.9.tgz",
+      "integrity": "sha512-7vNxXZ24OAgXxDKXYi9JtgWPMuNbBL3057Yf32Ux+/rVP4+EePgySCc+NNnn0tORi8qwqVreN8bdWqGIcSwNXg==",
+      "dependencies": {
+        "@types/interpret": "^1.1.1",
+        "@types/node": "^20.5.7",
+        "@types/semver": "^7.5.1",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.4",
+        "interpret": "^3.1.1",
+        "semver": "^7.5.4",
+        "tslib": "^2.6.2",
+        "yargs": "^17.7.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/graphile-config/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/graphile-config/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/graphile-config/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/graphile-config/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/graphile-config/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/graphile-config/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/graphile-config/node_modules/interpret": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+      "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/graphile-config/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/graphile-worker": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/graphile-worker/-/graphile-worker-0.16.6.tgz",
+      "integrity": "sha512-e7gGYDmGqzju2l83MpzX8vNG/lOtVJiSzI3eZpAFubSxh/cxs7sRrRGBGjzBP1kNG0H+c95etPpNRNlH65PYhw==",
+      "dependencies": {
+        "@graphile/logger": "^0.2.0",
+        "@types/debug": "^4.1.10",
+        "@types/pg": "^8.10.5",
+        "cosmiconfig": "^8.3.6",
+        "graphile-config": "^0.0.1-beta.4",
+        "json5": "^2.2.3",
+        "pg": "^8.11.3",
+        "tslib": "^2.6.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "graphile-worker": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/graphile-worker/node_modules/cosmiconfig": {
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+      "integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+      "dependencies": {
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
@@ -10997,6 +11819,15 @@
         }
       ]
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -11015,6 +11846,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/indent-string": {
@@ -11223,6 +12063,15 @@
       "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-plain-obj": {
@@ -11471,6 +12320,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "peer": true
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -11480,6 +12335,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -11542,6 +12403,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
       "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "peer": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -11611,6 +12481,21 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "engines": {
         "node": ">=6.11.5"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash.castarray": {
@@ -11762,7 +12647,7 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/map-limit": {
       "version": "0.0.1",
@@ -13127,6 +14012,12 @@
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg=="
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "peer": true
+    },
     "node_modules/needle": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
@@ -13439,6 +14330,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
+    },
     "node_modules/oidc-token-hash": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
@@ -13618,6 +14514,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "peer": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-try": {
@@ -13813,6 +14739,147 @@
         "@types/estree": "^1.0.0",
         "estree-walker": "^3.0.0",
         "is-reference": "^3.0.0"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.0.tgz",
+      "integrity": "sha512-34wkUTh3SxTClfoHB3pQ7bIMvw9dpFU1audQQeZG837fmHfHpr14n/AELVDoOYVDW2h5RDWU78tFjkD+erSBsw==",
+      "dependencies": {
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.0",
+        "pg-protocol": "^1.7.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+      "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA=="
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.7.0.tgz",
+      "integrity": "sha512-ZOBQForurqh4zZWjrgSwwAtzJ7QiRX0ovFkZr2klsen3Nm0aoh33Ls0fzfv3imeH/nw/O27cjdz5kzYJfeGp/g==",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.0.tgz",
+      "integrity": "sha512-hTK/mE36i8fDDhgDFjy6xNOG+LCorxLG3WO17tku+ij6sVHXh1jQUJ8hYAnRhNla4QVD2H8er/FOjc/+EgC6yQ=="
+    },
+    "node_modules/pg-types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pg/node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pg/node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/pick-by-alias": {
@@ -14064,6 +15131,46 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/postgres-array": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.2.tgz",
+      "integrity": "sha512-6faShkdFugNQCLwucjPcY5ARoW1SlbnrZjmGl0IrrqewpvxvhSLHimCVzqeuULCbG0fQv7Dtk1yDbG3xv7Veog==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w=="
+    },
     "node_modules/potpack": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
@@ -14180,7 +15287,7 @@
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.7.0.tgz",
       "integrity": "sha512-0rcfXO2ErmGAtxnuTNHQT9ztL0zZheQjOI/VNJzdq87C3TlGPQtMqtM+KCwU6XtmkoEr7vbCQqA7HF9IY0ST+Q==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/engines": "5.7.0"
@@ -15425,6 +16532,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -15579,6 +16694,12 @@
       "version": "2.5.9",
       "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
       "integrity": "sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg=="
+    },
+    "node_modules/sdp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.0.tgz",
+      "integrity": "sha512-d7wDPgDV3DDiqulJjKiV2865wKsJ34YI+NDREbm+FySq6WuKOikwyNQcm+doLAZ1O6ltdO0SeKle2xMpN3Brgw==",
+      "peer": true
     },
     "node_modules/selderee": {
       "version": "0.11.0",
@@ -15980,6 +17101,14 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
       "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg=="
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
@@ -16166,6 +17295,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/strip-indent": {
@@ -16528,6 +17666,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "peer": true
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -16736,10 +17880,10 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "devOptional": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16782,7 +17926,21 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tslib": {
       "version": "2.6.2",
@@ -16843,7 +18001,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17180,7 +18338,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -17346,6 +18504,19 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.1.tgz",
+      "integrity": "sha512-1AQO+d4ElfVSXyzNVTOewgGT/tAomwwztX/6e3totvyyzXPvXIIuUUjAmyZGbKBKbZOXauuJooZm3g6IuFuiNQ==",
+      "peer": true,
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
       }
     },
     "node_modules/whatwg-fetch": {
@@ -17571,6 +18742,14 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -17582,6 +18761,23 @@
       "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
@@ -17604,13 +18800,51 @@
         "node": ">=6"
       }
     },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/youtube-player": {
@@ -17651,126 +18885,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/react-email/node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.3.tgz",
-      "integrity": "sha512-6adp7waE6P1TYFSXpY366xwsOnEXM+y1kgRpjSRVI2CBDOcbRjsJ67Z6EgKIqWIue52d2q/Mx8g9MszARj8IEA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/react-email/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.3.tgz",
-      "integrity": "sha512-cuzCE/1G0ZSnTAHJPUT1rPgQx1w5tzSX7POXSLaS7w2nIUJUD+e25QoXD/hMfxbsT9rslEXugWypJMILBj/QsA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/react-email/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.3.tgz",
-      "integrity": "sha512-0D4/oMM2Y9Ta3nGuCcQN8jjJjmDPYpHX9OJzqk42NZGJocU2MqhBq5tWkJrUQOQY9N+In9xOdymzapM09GeiZw==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/react-email/node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.3.tgz",
-      "integrity": "sha512-ENPiNnBNDInBLyUU5ii8PMQh+4XLr4pG51tOp6aJ9xqFQ2iRI6IH0Ds2yJkAzNV1CfyagcyzPfROMViS2wOZ9w==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/react-email/node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.3.tgz",
-      "integrity": "sha512-BTAbq0LnCbF5MtoM7I/9UeUu/8ZBY0i8SFjUMCbPDOLv+un67e2JgyN4pmgfXBwy/I+RHu8q+k+MCkDN6P9ViQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/react-email/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.3.tgz",
-      "integrity": "sha512-AEHIw/dhAMLNFJFJIJIyOFDzrzI5bAjI9J26gbO5xhAKHYTZ9Or04BesFPXiAYXDNdrwTP2dQceYA4dL1geu8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/react-email/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.3.tgz",
-      "integrity": "sha512-vga40n1q6aYb0CLrM+eEmisfKCR45ixQYXuBXxOOmmoV8sYST9k7E3US32FsY+CkkF7NtzdcebiFT4CHuMSyZw==",
-      "cpu": [
-        "ia32"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/react-email/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.3.tgz",
-      "integrity": "sha512-Q1/zm43RWynxrO7lW4ehciQVj+5ePBhOK+/K2P7pLFX3JaJ/IZVC69SHidrmZSOkqz7ECIOhhy7XhAFG4JYyHA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/drc-portals/package.json
+++ b/drc-portals/package.json
@@ -13,7 +13,8 @@
     "start": "next start",
     "lint": "next lint",
     "version": "npm run build && ts-node cli/version-compose.ts && docker-compose build drc-portal-app",
-    "postversion": "docker-compose push drc-portal-app"
+    "postversion": "docker-compose push drc-portal-app",
+    "worker": "NODE_OPTIONS=\"--loader ts-node/esm\" graphile-worker"
   },
   "dependencies": {
     "@auth/prisma-adapter": "^1.0.5",
@@ -48,6 +49,7 @@
     "crypto-js": "^4.2.0",
     "fairshakeinsignia": "^1.0.3",
     "fs": "^0.0.1-security",
+    "graphile-worker": "^0.16.6",
     "html-entities": "^2.5.2",
     "js-cookie": "^3.0.5",
     "js-file-download": "^0.4.12",
@@ -87,11 +89,13 @@
     "@types/react-dom": "^18",
     "@types/react-plotly.js": "^2.6.3",
     "autoprefixer": "^10.0.1",
+    "dotenv": "^16.4.5",
     "postcss": "^8",
     "prisma": "^5.7.0",
     "sharp": "^0.32.6",
     "tailwindcss": "^3.3.0",
-    "ts-node": "^10.9.1",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5"
   }
 }

--- a/drc-portals/tasks/fairshake.ts
+++ b/drc-portals/tasks/fairshake.ts
@@ -1,0 +1,61 @@
+import type { JobHelpers } from "graphile-worker";
+import path from 'path'
+import prisma from "@/lib/prisma";
+import python from "@/utils/python";
+import graphile from "@/lib/graphile";
+
+export type FAIRShakeTaskPayload = {
+  link: string
+}
+
+const __rootdir = path.resolve(__dirname, '..', '..')
+
+export async function queue_fairshake(payload: FAIRShakeTaskPayload) {
+  const workerUtils = await graphile
+  await workerUtils.addJob('fairshake', payload)
+}
+
+export default async function process_fairshake(payload: FAIRShakeTaskPayload, helpers: JobHelpers) {
+  const { codeAsset, fileAsset, fairAssessments, ...asset } = await prisma.dccAsset.findUniqueOrThrow({
+    where: {
+      link: payload.link,
+    },
+    include: {
+      codeAsset: true,
+      fileAsset: true,
+      fairAssessments: {
+        select: {
+          id: true,
+        }
+      },
+    },
+  })
+  helpers.abortSignal?.throwIfAborted()
+  if (fairAssessments.length > 0) {
+    helpers.logger.warn('FAIR assessment already performed')
+    return
+  }
+  if (asset.deleted) {
+    helpers.logger.warn('Will not assess deleted asset')
+    return
+  }
+  helpers.logger.info(`Performing FAIR assessment on ${payload.link}...`)
+  process.env.PYTHONPATH = path.resolve(__rootdir, 'database', 'fair_assessment')
+  const assessment: {
+    id: string,
+    dcc_id: string,
+    type: string,
+    link: string,
+    rubric: string,
+    timestamp: string, // isoformat
+  } = await python('assess_fair.assess_dcc_asset', {
+    kargs: [
+      {...asset, ...(fileAsset ?? codeAsset ?? {})},
+    ],
+  }, msg => {helpers.logger.debug(msg)})
+  helpers.abortSignal?.throwIfAborted()
+  helpers.logger.info(`Registering FAIR assessment for ${payload.link}...`)
+  await prisma.fairAssessment.create({
+    data: assessment,
+  })
+}

--- a/drc-portals/tasks/fairshake.ts
+++ b/drc-portals/tasks/fairshake.ts
@@ -46,7 +46,7 @@ export default async function process_fairshake(payload: FAIRShakeTaskPayload, h
     dcc_id: string,
     type: string,
     link: string,
-    rubric: string,
+    rubric: Record<string, number>,
     timestamp: string, // isoformat
   } = await python('assess_fair.assess_dcc_asset', {
     kargs: [
@@ -56,6 +56,13 @@ export default async function process_fairshake(payload: FAIRShakeTaskPayload, h
   helpers.abortSignal?.throwIfAborted()
   helpers.logger.info(`Registering FAIR assessment for ${payload.link}...`)
   await prisma.fairAssessment.create({
-    data: assessment,
+    data: {
+      id: assessment.id,
+      dcc_id: assessment.dcc_id,
+      type: assessment.type,
+      link: assessment.link,
+      rubric: assessment.rubric,
+      timestamp: new Date(assessment.timestamp),
+    },
   })
 }

--- a/drc-portals/tasks/fairshake.ts
+++ b/drc-portals/tasks/fairshake.ts
@@ -50,7 +50,10 @@ export default async function process_fairshake(payload: FAIRShakeTaskPayload, h
     timestamp: string, // isoformat
   } = await python('assess_fair.assess_dcc_asset', {
     kargs: [
-      {...asset, ...(fileAsset ?? codeAsset ?? {})},
+      {
+        ...{...asset, created: asset.created.toISOString(), lastmodified: asset.lastmodified.toISOString()},
+        ...(fileAsset ? {...fileAsset, size: fileAsset.size?.toString()} : codeAsset ?? {})
+      },
     ],
   }, msg => {helpers.logger.debug(msg)})
   helpers.abortSignal?.throwIfAborted()

--- a/drc-portals/tsconfig.json
+++ b/drc-portals/tsconfig.json
@@ -2,7 +2,11 @@
   "ts-node": {
     "compilerOptions": {
       "module": "CommonJS"
-    }
+    },
+    "require": [
+      "dotenv/config",
+      "tsconfig-paths/register"
+    ]
   },
   "compilerOptions": {
     "target": "es5",

--- a/drc-portals/utils/helper.py
+++ b/drc-portals/utils/helper.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+# Stolen from https://raw.githubusercontent.com/MaayanLab/Playbook-Workflow-Builder/refs/heads/main/utils/helper.py
+# Usage: ./python_helper.py mod.path.func_name <<< '{"kargs": ["value"]}' >>> '{"output": "json"}'
+import sys, json, inspect, pathlib, importlib, contextlib, traceback
+_, pathspec = sys.argv
+name, _, attr = pathspec.rpartition('.')
+sys.path.insert(0, str(pathlib.Path(__file__).parent.parent.absolute()))
+try:
+  with contextlib.redirect_stdout(sys.stderr):
+    mod = importlib.import_module(name)
+    func = getattr(mod, attr)
+    args = json.load(sys.stdin)
+    out = func(*(args.get('kargs') or []), **(args.get('kwargs') or {}))
+  if inspect.isgenerator(out):
+    sys.stdout.buffer.writelines(out)
+  else:
+    json.dump(dict(data=out), sys.stdout, allow_nan=False)
+except Exception as e:
+  traceback.print_exc(file=sys.stderr)
+  json.dump(dict(error=str(e)), sys.stdout, allow_nan=False)

--- a/drc-portals/utils/python.ts
+++ b/drc-portals/utils/python.ts
@@ -1,0 +1,98 @@
+/** Stolen from https://raw.githubusercontent.com/MaayanLab/Playbook-Workflow-Builder/refs/heads/main/utils/python.ts
+ * Run python scripts/functions from typescript
+ * Usage:
+ * ```ts
+ * import python from '@/utils/python'
+ * async function run() {
+ *   try {
+ *     const result = await python('@/path/from/root/myscript.py', 'myfunc', { kargs: [ 'myarg' ], kwargs: { 'myarg2': '2' } })
+ *   } catch (e) {
+ *     // e is a ProcessError
+ *   }
+ * }
+ */
+import type * as child_process_type from 'child_process'
+import type * as path_type from 'path'
+import { Readable } from 'stream'
+
+export class ProcessError extends Error {
+  constructor(public message: string, public exitcode: number | null) {
+    super(message)
+    this.name = 'ProcessError'
+  }
+}
+
+/**
+ * @param script: of the form python_file.py:func_in_file
+ * @param args: The kwargs to provide to the file
+ */
+export default function python<T>(pathspec: string, args: { kargs?: unknown[], kwargs?: Record<string, unknown> }, callback?: (data: string) => void): Promise<T> {
+  if (typeof window !== 'undefined') throw new Error("python is server side only")
+  const spawn = typeof window === 'undefined' ? (require('child_process') as typeof child_process_type).spawn : undefined
+  const path = typeof window === 'undefined' ? require('path') as typeof path_type : undefined
+  return new Promise((resolve, reject) => {
+    let stdin: string
+    try {
+      stdin = JSON.stringify(args)
+    } catch (e) {
+      throw new ProcessError(`Process input could not be serialized`, null)
+    }
+    if (typeof spawn === 'undefined') throw new Error("python is server side only")
+    if (typeof path === 'undefined') throw new Error("python is server side only")
+    const proc = spawn(process.env.PYTHON_BIN || 'python', [
+      path.join(process.env.PYTHON_ROOT || '', 'utils', 'helper.py'),
+      pathspec,
+    ], { env: { ...process.env } })
+    let stdout = ''
+    proc.stdout.on('data', (chunk: string) => { stdout += chunk })
+    proc.stderr.on('data', callback !== undefined ? (chunk) => callback(chunk.toString()) : (chunk: string) => { console.warn(`[${pathspec}]: ${chunk.toString()}`) })
+    proc.on('close', (code) => {
+      try {
+        const stdout_parsed = JSON.parse(stdout)
+        if (stdout_parsed.error) reject(new ProcessError(stdout_parsed.error, code))
+        else if (code !== 0) reject(new ProcessError(`[${pathspec}]: ${`Process exited with unexpected code ${code}`}`, code))
+        else resolve(stdout_parsed.data)
+      } catch (e) {
+        console.debug(stdout)
+        reject(new ProcessError(`[${pathspec}]: Process output could not be parsed as json. ${e}`, code))
+      }
+    })
+    proc.stdin.end(stdin)
+  })
+}
+
+
+/**
+ * @param script: of the form python_file.py:func_in_file
+ * @param args: The kwargs to provide to the file
+ */
+export function pythonStream(pathspec: string, args: { kargs?: unknown[], kwargs?: Record<string, unknown> }): Readable {
+  if (typeof window !== 'undefined') throw new Error("python is server side only")
+  const spawn = typeof window === 'undefined' ? (require('child_process') as typeof child_process_type).spawn : undefined
+  const path = typeof window === 'undefined' ? require('path') as typeof path_type : undefined
+  let stdin: string
+  try {
+    stdin = JSON.stringify(args)
+  } catch (e) {
+    throw new ProcessError(`Process input could not be serialized`, null)
+  }
+  if (typeof spawn === 'undefined') throw new Error("python is server side only")
+  if (typeof path === 'undefined') throw new Error("python is server side only")
+  const proc = spawn(process.env.PYTHON_BIN || 'python3', [
+    path.join(process.env.PYTHON_ROOT || '', 'utils', 'helper.py'),
+    pathspec,
+  ], { env: { ...process.env } })
+  let stderr = ''
+  proc.stderr.on('data', (chunk: string) => { stderr += chunk })
+  proc.on('close', (code) => {
+    if (code !== 0) {
+      throw new ProcessError(`[${pathspec}]: ${stderr || `Process exited with unexpected code ${code}`}`, code)
+    } else {
+      if (stderr) {
+        console.warn(`[${pathspec}]: ${stderr}`)
+      }
+    }
+  })
+  proc.stdin.end(stdin)
+  return proc.stdout
+}

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,25 @@
+# expected to have the parent directory as context
+
+FROM node:21
+
+WORKDIR /app
+
+RUN set -x \
+  && apt-get update \
+  && apt-get install -y \
+    python3 \
+    python3-pip
+
+ADD database/ database/
+RUN set -x \
+  && pip install --break-system-packages \
+    -r database/requirements.txt \
+    -r database/fair_assessment/requirements.txt
+
+ADD drc-portals/ drc-portals/
+WORKDIR /app/drc-portals
+RUN npm i
+
+ENV PYTHON_BIN=python3
+ENV DATABASE_URL ""
+CMD ["npm", "run", "worker"]


### PR DESCRIPTION
Adopt Graphile Worker job queue to automatically run FAIR assessments on submitted assets.

![scrapbook](https://github.com/user-attachments/assets/42d461c7-3fd3-4ed3-a86f-f04784f06168)

Outline:
- [x] implement worker queue system
- [x] create fairshake assessment task
- [x] queue fairshake task when assets are uploaded
- [x] run workers in production
- [ ] allow users to view logs for debugging unexpected results
- [ ] allow admins to view/manage graphile job queue
