### PR TITLE
Add schema.org Dataset metadata for dcc assets and c2m2 files

### DIFF
--- a/drc-portals/app/data/processed/c2m2_file/[id]/page.tsx
+++ b/drc-portals/app/data/processed/c2m2_file/[id]/page.tsx
@@ -5,6 +5,7 @@ import LandingPageLayout from "@/app/data/processed/LandingPageLayout";
 import { Metadata, ResolvingMetadata } from 'next'
 import { cache } from "react";
 import { notFound } from "next/navigation";
+import { metadata } from "@/app/data/layout";
 
 type PageProps = { params: { id: string } }
 
@@ -26,6 +27,7 @@ const getItem = cache((id: string) => prisma.c2M2FileNode.findUnique({
             short_label: true,
             label: true,
             icon: true,
+            homepage: true,
           }
         },
       },
@@ -53,32 +55,76 @@ export async function generateMetadata(props: PageProps, parent: ResolvingMetada
 export default async function Page(props: PageProps) {
   const item = await getItem(props.params.id)
   if (!item) return notFound()
-    return (
-    <LandingPageLayout
-      icon={item.node.dcc?.icon ? { href: `/info/dcc/${item.node.dcc.short_label}`, src: item.node.dcc.icon, alt: item.node.dcc.label } : undefined}
-      title={item.node.label}
-      subtitle={type_to_string('c2m2_file', null)}
-      description={format_description(item.node.description)}
-      metadata={[
-        item.node.dcc?.label ? {
-          label: 'Project',
-          value: <Link href={`/info/dcc/${item.node.dcc.short_label}`} className="underline cursor-pointer text-blue-600">{item.node.dcc.label}</Link>
-        } : null,
-        item.persistent_id ? {
-          label: 'Persistent ID',
-          value: /^https?:\/\//.exec(item.persistent_id) !== null ?
-            <Link href={item.persistent_id} className="underline cursor-pointer text-blue-600">{item.persistent_id}</Link>
-            : item.persistent_id,
-        } : null,
-        process.env.PUBLIC_URL && item.access_url ? { label: 'DRS', value: `${process.env.PUBLIC_URL.replace(/^https?/, 'drs')}/${props.params.id}` } : null,
-        item.size_in_bytes ? {
-          label: 'Size in Bytes',
-          value: item.size_in_bytes.toLocaleString(),
-        } : null,
-        { label: 'File Format', value: item.file_format },
-        { label: 'Assay Type', value: item.assay_type },
-        { label: 'Data Type', value: item.data_type },
-      ]}
-    />
+  return (
+    <>
+      <LandingPageLayout
+        icon={item.node.dcc?.icon ? { href: `/info/dcc/${item.node.dcc.short_label}`, src: item.node.dcc.icon, alt: item.node.dcc.label } : undefined}
+        title={item.node.label}
+        subtitle={type_to_string('c2m2_file', null)}
+        description={format_description(item.node.description)}
+        metadata={[
+          item.node.dcc?.label ? {
+            label: 'Project',
+            value: <Link href={`/info/dcc/${item.node.dcc.short_label}`} className="underline cursor-pointer text-blue-600">{item.node.dcc.label}</Link>
+          } : null,
+          item.persistent_id ? {
+            label: 'Persistent ID',
+            value: /^https?:\/\//.exec(item.persistent_id) !== null ?
+              <Link href={item.persistent_id} className="underline cursor-pointer text-blue-600">{item.persistent_id}</Link>
+              : item.persistent_id,
+          } : null,
+          process.env.PUBLIC_URL && item.access_url ? { label: 'DRS', value: `${process.env.PUBLIC_URL.replace(/^https?/, 'drs')}/${props.params.id}` } : null,
+          item.size_in_bytes ? {
+            label: 'Size in Bytes',
+            value: item.size_in_bytes.toLocaleString(),
+          } : null,
+          { label: 'File Format', value: item.file_format },
+          { label: 'Assay Type', value: item.assay_type },
+          { label: 'Data Type', value: item.data_type },
+        ]}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify({
+          "@context":"http://schema.org",
+          "@type":"Dataset",
+          "name":item.node.label,
+          "description":item.node.description,
+          "keywords":[
+            metadata.keywords,
+            item.node.dcc?.short_label,
+            item.assay_type,
+            item.data_type,
+            item.file_format,
+          ].join(', '),
+          "funder":{
+            "@type": "Organization",
+            "sameAs": "https://commonfund.nih.gov/dataecosystem",
+            "name": "National Institute of Health (NIH) Common Fund Data Ecosystem (CFDE)"
+          },
+          "provider":{
+            "@type":"Organization",
+            "name":"Common Fund Data Ecosystem (CFDE) Data Resource Center (DRC)",
+            "url":"https://info.cfde.cloud"
+          },
+          "creator": item.node.dcc ? {
+            "@type": "Organization",
+            "name": item.node.dcc.label,
+            "url": item.node.dcc.homepage || `https://info.cfde.cloud/dcc/${item.node.dcc.short_label}`
+          } : undefined,
+          "distribution": item.access_url ? [
+            {
+              "@type":"DataDownload",
+              name: item.node.label,
+              description: item.node.description,
+              measurementMethod: item.assay_type,
+              contentUrl: item.access_url,
+              contentSize: item.size_in_bytes ? BigInt(item.size_in_bytes).toString() : undefined,
+            },
+          ] : undefined,
+          "citation":undefined
+        }) }}
+      />
+    </>
   )
 }

--- a/drc-portals/app/data/processed/c2m2_file/[id]/page.tsx
+++ b/drc-portals/app/data/processed/c2m2_file/[id]/page.tsx
@@ -97,6 +97,11 @@ export default async function Page(props: PageProps) {
             item.data_type,
             item.file_format,
           ].join(', '),
+          "includedInDataCatalog": {
+            "@type": "DataCatalog",
+            "name": "Common Fund Data Ecosystem (CFDE) Data Portal",
+            "url": "https://data.cfde.cloud"
+          },
           "funder":{
             "@type": "Organization",
             "sameAs": "https://commonfund.nih.gov/dataecosystem",
@@ -122,7 +127,6 @@ export default async function Page(props: PageProps) {
               contentSize: item.size_in_bytes ? BigInt(item.size_in_bytes).toString() : undefined,
             },
           ] : undefined,
-          "citation":undefined
         }) }}
       />
     </>

--- a/drc-portals/app/data/processed/dcc_asset/[id]/page.tsx
+++ b/drc-portals/app/data/processed/dcc_asset/[id]/page.tsx
@@ -5,6 +5,7 @@ import LandingPageLayout from "@/app/data/processed/LandingPageLayout";
 import { Metadata, ResolvingMetadata } from 'next'
 import { cache } from "react";
 import { notFound } from "next/navigation";
+import { metadata } from "@/app/data/layout";
 
 type PageProps = { params: { id: string } }
 
@@ -32,6 +33,7 @@ const getItem = cache((id: string) => prisma.dCCAssetNode.findUnique({
             short_label: true,
             label: true,
             icon: true,
+            homepage: true,
           }
         },
       },
@@ -60,22 +62,65 @@ export default async function Page(props: { params: { id: string } }) {
   const item = await getItem(props.params.id)
   if (!item) return notFound()
   return (
-    <LandingPageLayout
-      icon={item.node.dcc?.icon ? { href: `/info/dcc/${item.node.dcc.short_label}`, src: item.node.dcc.icon, alt: item.node.dcc.label } : undefined}
-      title={item.node.label}
-      subtitle={type_to_string('dcc_asset', null)}
-      description={format_description(item.node.description)}
-      metadata={[
-        ...(item.node.dcc?.label ? [
-          { label: 'Project', value: <Link href={`/info/dcc/${item.node.dcc.short_label}`} className="underline cursor-pointer text-blue-600">{item.node.dcc.label}</Link> },
-          item.dcc_asset.fileAsset ? { label: 'Asset', value:  <Link href={`/data/matrix/${item.node.dcc.short_label}#${item.dcc_asset.fileAsset.filetype}`} className="underline cursor-pointer text-blue-600">Asset Page</Link> } : null,
-         ] : []),
-        { label: 'Link', value: <Link href={item.dcc_asset.link} className="underline cursor-pointer text-blue-600">{item.dcc_asset.link}</Link> },
-        process.env.PUBLIC_URL ? { label: 'DRS', value: `${process.env.PUBLIC_URL.replace(/^https?/, 'drs')}/${props.params.id}` } : null,
-        item.dcc_asset.fileAsset ? { label: 'File Type', value: item.dcc_asset.fileAsset.filetype } : null,
-        item.dcc_asset.fileAsset ? { label: 'Size in Bytes', value: item.dcc_asset.fileAsset.size?.toLocaleString() ?? 'unknown' } : null,
-        { label: 'Last Modified', value: item.dcc_asset.lastmodified.toLocaleDateString() },
-      ]}
-    />
+    <>
+      <LandingPageLayout
+        icon={item.node.dcc?.icon ? { href: `/info/dcc/${item.node.dcc.short_label}`, src: item.node.dcc.icon, alt: item.node.dcc.label } : undefined}
+        title={item.node.label}
+        subtitle={type_to_string('dcc_asset', null)}
+        description={format_description(item.node.description)}
+        metadata={[
+          ...(item.node.dcc?.label ? [
+            { label: 'Project', value: <Link href={`/info/dcc/${item.node.dcc.short_label}`} className="underline cursor-pointer text-blue-600">{item.node.dcc.label}</Link> },
+            item.dcc_asset.fileAsset ? { label: 'Asset', value:  <Link href={`/data/matrix/${item.node.dcc.short_label}#${item.dcc_asset.fileAsset.filetype}`} className="underline cursor-pointer text-blue-600">Asset Page</Link> } : null,
+          ] : []),
+          { label: 'Link', value: <Link href={item.dcc_asset.link} className="underline cursor-pointer text-blue-600">{item.dcc_asset.link}</Link> },
+          process.env.PUBLIC_URL ? { label: 'DRS', value: `${process.env.PUBLIC_URL.replace(/^https?/, 'drs')}/${props.params.id}` } : null,
+          item.dcc_asset.fileAsset ? { label: 'File Type', value: item.dcc_asset.fileAsset.filetype } : null,
+          item.dcc_asset.fileAsset ? { label: 'Size in Bytes', value: item.dcc_asset.fileAsset.size?.toLocaleString() ?? 'unknown' } : null,
+          { label: 'Last Modified', value: item.dcc_asset.lastmodified.toLocaleDateString() },
+        ]}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify({
+          "@context":"http://schema.org",
+          "@type":"Dataset",
+          "name":item.node.label,
+          "description":item.node.description,
+          "keywords":[
+            metadata.keywords,
+            item.node.dcc?.short_label,
+            item.dcc_asset.fileAsset?.filetype,
+          ].join(', '),
+          "funder":{
+             "@type": "Organization",
+             "sameAs": "https://commonfund.nih.gov/dataecosystem",
+             "name": "National Institute of Health (NIH) Common Fund Data Ecosystem (CFDE)"
+          },
+          "provider":{
+            "@type":"Organization",
+            "name":"Common Fund Data Ecosystem (CFDE) Data Resource Center (DRC)",
+            "url":"https://info.cfde.cloud"
+          },
+          "creator": item.node.dcc ? {
+            "@type": "Organization",
+            "name": item.node.dcc.label,
+            "url": item.node.dcc.homepage || `https://info.cfde.cloud/dcc/${item.node.dcc.short_label}`
+          } : undefined,
+          "distribution":item.dcc_asset.fileAsset ? [
+            {
+              "@type":"DataDownload",
+              name: item.node.label,
+              description: item.node.description,
+              measurementMethod: item.dcc_asset.fileAsset.filetype,
+              uploadDate: item.dcc_asset.lastmodified.toISOString(),
+              contentUrl: item.dcc_asset.link,
+              contentSize: item.dcc_asset.fileAsset?.size ? BigInt(item.dcc_asset.fileAsset.size).toString() : undefined,
+            },
+          ] : undefined,
+          "citation":undefined
+        }) }}
+      />
+    </>
   )
 }

--- a/drc-portals/app/data/processed/dcc_asset/[id]/page.tsx
+++ b/drc-portals/app/data/processed/dcc_asset/[id]/page.tsx
@@ -92,6 +92,11 @@ export default async function Page(props: { params: { id: string } }) {
             item.node.dcc?.short_label,
             item.dcc_asset.fileAsset?.filetype,
           ].join(', '),
+          "includedInDataCatalog": {
+            "@type": "DataCatalog",
+            "name": "Common Fund Data Ecosystem (CFDE) Data Portal",
+            "url": "https://data.cfde.cloud"
+          },
           "funder":{
              "@type": "Organization",
              "sameAs": "https://commonfund.nih.gov/dataecosystem",
@@ -118,7 +123,6 @@ export default async function Page(props: { params: { id: string } }) {
               contentSize: item.dcc_asset.fileAsset?.size ? BigInt(item.dcc_asset.fileAsset.size).toString() : undefined,
             },
           ] : undefined,
-          "citation":undefined
         }) }}
       />
     </>


### PR DESCRIPTION
An example schema.org Dataset specification for: https://data.cfde.cloud/processed/dcc_asset/329b6972-dcd7-515e-8075-e0c8ca37767e
```json
{
  "@context": "http://schema.org",
  "@type": "Dataset",
  "name": "IDG_DrugCentral_Target.dmt",
  "description": "A XMT processed data file from IDG",
  "keywords": "big data, bioinformatics, bone, c2m2, cancer, cell line, cfde, common fund data ecosystem, common fund, data ecosystem, data portal, data, dataset, diabetes, disease, drug discovery, drug, enrichment analysis, gene set library, gene set, gene, genomics, glycan, heart, kidney, knowledge, liver, machine learning, metabolomics, motifs, neurons, nih common fund, peturbation, pharmacology, phenotype, protein, proteomics, RNA-seq, RNAseq, scRNA-seq, single cell, skin, standard, systems biology, target discovery, target, therapeutics, tissue, transcriptomics, variants, workbench, IDG, XMT",
  "includedInDataCatalog": {
    "@type": "DataCatalog",
    "name": "Common Fund Data Ecosystem (CFDE) Data Portal",
    "url": "https://data.cfde.cloud"
  },
  "funder": {
    "@type": "Organization",
    "sameAs": "https://commonfund.nih.gov/dataecosystem",
    "name": "National Institute of Health (NIH) Common Fund Data Ecosystem (CFDE)"
  },
  "provider": {
    "@type": "Organization",
    "name": "Common Fund Data Ecosystem (CFDE) Data Resource Center (DRC)",
    "url": "https://info.cfde.cloud"
  },
  "creator": {
    "@type": "Organization",
    "name": "Illuminating the Druggable Genome",
    "url": "https://druggablegenome.net/"
  },
  "distribution": [
    {
      "@type": "DataDownload",
      "name": "IDG_DrugCentral_Target.dmt",
      "description": "A XMT processed data file from IDG",
      "measurementMethod": "XMT",
      "uploadDate": "2020-03-10T00:00:00.000Z",
      "contentUrl": "https://cfde-drc.s3.amazonaws.com/IDG/XMT/2020-03-10/IDG_XMT_2020-03-10_DrugCentral_Target.dmt",
      "contentSize": "126906"
    }
  ]
}
```