### PR TITLE
Update C2M2.mdx to use link to actual C2M2 json schema file

### DIFF
--- a/drc-portals/app/info/documentation/markdown/C2M2.mdx
+++ b/drc-portals/app/info/documentation/markdown/C2M2.mdx
@@ -30,7 +30,7 @@ This page is adapted from the [original C2M2 documentation](https://github.com/n
 - The [c2m2-frictionless-dataclass](https://github.com/nih-cfde/c2m2-frictionless-dataclass/tree/main) 
   - This repository includes the `c2m2-frictionless` Python package, which contains specific helper functions for C2M2 datapackage building and validation. 
   - This package is not designed to generate a complete C2M2 datapackage from any given data, but should be used in collaboration with the provided schema and ontology preparation scripts, as well as with DCC-specific scripts.
-- The most up-to-date [C2M2 JSON schema](https://osf.io/c63aw/)
+- The most up-to-date [C2M2 JSON schema](https://osf.io/3sra4/)
 - The most up-to-date [C2M2 ontology preparation script and files](https://osf.io/bq6k9/)
 - The original [C2M2 documentation](https://github.com/nih-cfde/c2m2/blob/master/draft-C2M2_specification/README.md) from the CFDE Coordination Center contains more details on the concepts discussed here.
 


### PR DESCRIPTION
Update C2M2.mdx to use link to actual C2M2 json schema file: https://osf.io/c63aw/ --> https://osf.io/3sra4/