### PR TITLE
Carousel - remove title & center indicaters

### DIFF
--- a/drc-portals/components/misc/Carousel/ClientCarousel.tsx
+++ b/drc-portals/components/misc/Carousel/ClientCarousel.tsx
@@ -19,12 +19,13 @@ export default function ClientCarousel({children, title}: {children: React.React
             }} indicators={true}
             indicatorContainerProps={{
               style: {
-                  position: "absolute",
-                  bottom: width === "sm" ? "15%": "10%",
-                  right:  ['sm', 'md', 'xs'].indexOf(width) > -1 ? "0": "40%",
+                position: "absolute",
+                bottom: "5%", 
+                left: "45%",  
+                transform: "translate(-50%, -50%)",  
+              
               }
-      
-          }}
+            }}
           >
               {children}
           </Carousel>

--- a/drc-portals/components/misc/Carousel/ServerCarousel.tsx
+++ b/drc-portals/components/misc/Carousel/ServerCarousel.tsx
@@ -122,7 +122,7 @@ export default async function ServerCarousel () {
         </div>
     ))
 
-    return <ClientCarousel title="PRODUCTS, PARTNERSHIPS, & EVENTS">{children}</ClientCarousel>
+    return <ClientCarousel title="">{children}</ClientCarousel>
 
 }
 


### PR DESCRIPTION
Carousel on the Info portal landing page
- Remove the title 'PRODUCTS, PARTNERSHIPS, & EVENTS'
- Center indicator dots under the carousel box. 


![image](https://github.com/user-attachments/assets/9a612f66-eb5f-4d42-888d-e72ec2f9e8f3)
