### PR TITLE
Add a url for constructing a hub.txt file for the genome-browser

### DIFF
--- a/drc-portals/app/data/c2m2/file/[id_namespace]/[local_id]/genome-browser/hub.txt/route.ts
+++ b/drc-portals/app/data/c2m2/file/[id_namespace]/[local_id]/genome-browser/hub.txt/route.ts
@@ -1,0 +1,104 @@
+/**
+ * 
+ * Based on:
+ *  https://genome.ucsc.edu/goldenPath/help/hgTracksHelp.html#UseOneFile
+ * 
+ * This page essentially defines a hub.txt file for any file in the c2m2
+ *  but it will only work for files that:
+ * 
+ * 1. have file_format of VCF, bigBED, or bigWig
+ * 2. have a subject attached with the taxonomy 9606 (human)
+ * 3. have a publicly accessible ~access_url~ persistent_id with the actual data
+ * 
+ * We use the genome: hg19  but this may not be accurate,
+ *  it's unclear how we'd determine the correct one at this stage.
+ * 
+ * A hub can thus be assembled by pointing to the url at:
+ *  https://cfde.cloud/data/c2m2/file/{id_namespace}/{local_id}/genome-browser/hub.txt
+ * 
+ */
+import c2m2 from "@/lib/prisma/c2m2"
+
+export async function GET(
+  request: Request,
+  props: { params: Promise<{ id_namespace: string, local_id: string }> }
+) {
+  const params = await props.params
+  const file = await c2m2.file.findUnique({
+    where: {
+      id_namespace_local_id: { id_namespace: params.id_namespace, local_id: params.local_id }
+    },
+    select: {
+      filename: true,
+      local_id: true,
+      file_format: true,
+      // access_url: true,
+      persistent_id: true,
+      project: {
+        select: {
+          name: true,
+        },
+      },
+      file_describes_subject: {
+        select: {
+          subject: {
+            select: {
+              subject_role_taxonomy: {
+                select: {
+                  taxonomy_id: true,
+                },
+              },
+            },
+          },
+        },
+        take: 1,
+      }
+    },
+  })
+  if (!file) return new Response(`File not found`, {status: 404})
+  let response = `
+hub CFDEDataPortalHub
+shortLabel CFDE Data Portal Hub
+longLabel Genome Browser for data in the Common Fund Data Ecosystem
+useOneFile on
+email help@cfde.cloud
+`
+  if (file.file_describes_subject[0].subject.subject_role_taxonomy[0].taxonomy_id === '9606') {
+    response += `
+genome hg19
+`
+  } else {
+    return new Response(`Unsure which genome to use`, {status: 400})
+  }
+  if (file.file_format === 'format:3016') { // VCF
+    response += `
+track vcf
+type vcfTabix
+shortLabel ${file.local_id}
+longLabel ${file.filename} from ${file.project.name}
+bigDataUrl ${/*file.access_url*/file.persistent_id}
+visibility pack
+maxWindowToDraw 200000
+`
+  // } else if (file.file_format === 'format:3003') { // BED
+  } else if (file.file_format === 'format:3004') { // bigBED
+    response += `
+track bigBed
+type bigBed
+shortLabel ${file.local_id}
+longLabel ${file.filename} from ${file.project.name}
+bigDataUrl ${/*file.access_url*/file.persistent_id}
+`
+  } else if (file.file_format === 'format:3006') { // bigWig
+    response += `
+track bigWig
+type bigWig
+shortLabel ${file.local_id}
+longLabel ${file.filename} from ${file.project.name}
+bigDataUrl ${/*file.access_url*/file.persistent_id}
+`
+  } else {
+    return new Response(`Compatible file format found`, {status: 400})
+  }
+  return new Response(response, { headers: { 'Content-Type': 'text/plain' } })
+}


### PR DESCRIPTION
Based on:
 https://genome.ucsc.edu/goldenPath/help/hgTracksHelp.html#UseOneFile

This page essentially defines a hub.txt file for any file in the c2m2
 but it will only work for files that:

1. have file_format of VCF, bigBED, or bigWig
2. have a subject attached with the taxonomy 9606 (human)
3. have a publicly accessible ~access_url~ persistent_id with the actual data

We use the genome: hg19  but this may not be accurate,
 it's unclear how we'd determine the correct one at this stage.

A hub can thus be assembled by pointing to the url at:
 https://cfde.cloud/data/c2m2/file/{id_namespace}/{local_id}/genome-browser/hub.txt


Some caveats of this, if they weren't already obvious:

- We don't actually have `access_url`s yet, and the only files which could ever work do not define the right urls in the `persistent_id` field.
- even when we do have `access_url`, we'll possibly have DRS URIs which it doesn't seem the genome browser will be able to handle
- the current method of choosing the genome leaves much to be desired
  - missing other organisms
  - no guarantee that it's the right one

Because of these caveats we need to think more about how we can get the other information to support this use case. We'll need to:
- specify the genome in use when providing VCF,bigBed, or bigWig files
- provide an access url specific to those files

**Thoughts**: As this is rather specific to these types of files, it would belong in an independent table anyway that simply lists all genome-browser compatible files, it feels to me like it is just a bit out of scope of the current c2m2 and would be more useful as an independent effort to gather "tracks" from DCCs, perhaps as another element of the data matrix.